### PR TITLE
addresses #26, decided a function isn't necessary 

### DIFF
--- a/include/canbus.h
+++ b/include/canbus.h
@@ -105,6 +105,6 @@ extern uint32_t last_can_update;
 
 
 // Public Functions
-void can_receive();
+extern void can_receive();
 
 #endif // CANBUS_H

--- a/include/screen.h
+++ b/include/screen.h
@@ -200,9 +200,14 @@ void main_display(){
 	FTImpl.ColorRGB(col);
 	make_pill(x, y);
 	FTImpl.ColorRGB(0, 0, 0);
-	FTImpl.Cmd_Number(x-15, y, 28, FT_OPT_CENTER, veh.v_int);
+
+	// this is still really dumb, but at least it's not expensive
+	int v_int = veh.voltage;
+	float v_fl = (float)((veh.voltage - v_int) * 10);
+
+	FTImpl.Cmd_Number(x-15, y, 28, FT_OPT_CENTER, v_int);
 	FTImpl.Cmd_Text(x, y, 28, FT_OPT_CENTER, ".");
-	FTImpl.Cmd_Number(x+7, y, 28, FT_OPT_CENTER, veh.v_fl);
+	FTImpl.Cmd_Number(x+7, y, 28, FT_OPT_CENTER, v_fl);
 	FTImpl.Cmd_Text(x+27, y, 28, FT_OPT_CENTER, "V");
 
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -80,9 +80,6 @@ void loop(){
 			warning = 0;
 		}
 
-		veh.v_int = veh.voltage;
-		veh.v_fl = (float)((veh.voltage - veh.v_int)*10);
-
 		shift_lights.Update(veh.gear, veh.rpm);
 		c_time = millis();
 	}


### PR DESCRIPTION
since v_fl and f_int are only used in one place and a function call would be pointless. considered a static inline, but again, no point as it would only be used once. In the end, just moved the conversion from float to int + float into the function in screen.h where it is used. This should technically be the most efficient way to do it, barring the fact that it's still really dumb that we have to do it at all.

Summary of changes:
1. added v_int and v_fl generation code to screen.h:main_display() (only place it is used)
2. removed said code from main.cpp:loop() where it was being called much more often than required (we receive CAN messages more frequently than we refresh the screen)
3. also updated canbus.h:can_receive() definition to be extern. I believe this is required, not sure why it wasn't throwing an error without it. Not relevant to this issue but too small to need a separate branch and PR.

closes #26 