### PR TITLE
Split screen.h into screen.cpp + screen.h

### DIFF
--- a/include/VehicleData.h
+++ b/include/VehicleData.h
@@ -1,0 +1,76 @@
+#pragma once
+
+#include <inttypes.h>
+
+/*
+ * TYPEDEFS
+ */
+
+
+/*
+ * data pertaining to tuning launch control from the steering wheel
+ * TODO: store this in eeprom and fetch on boot, returning to default vals
+ * if unset
+ */
+typedef struct s_launch_cnf {
+	uint8_t rpm = 6000/100;		// default value for launch rpm
+	uint8_t th_speed = 30;		// default value for threshold speed
+} launch_cnf_S;
+
+/*
+ * Data that pertains to Steering Wheel IO
+ */
+
+typedef struct s_io_state {
+	/* the four switches on the bottom of the steering wheel
+	 * not counting the one in the middle
+	 * numbered from left to right
+	 */
+	bool sw1;
+	bool sw2;
+	bool sw3;
+	bool sw4;
+	/*
+	 * left and right paddle buttons
+	 */
+	bool pl;
+	bool pr;
+	/*
+	 * front top left and right buttons
+	 */
+	bool tl;
+	bool tr;
+	// lower middle button
+	bool mid;
+	/*  remote start FLAG, not IO. True when both TL and TR have been
+	 * pressed for sufficiently long
+	 * TODO: move this somewhere else maybe? idk
+	 */
+	bool remote_start;
+} io_state_S;
+
+typedef struct s_veh_data {
+	int8_t gear;
+	bool launch;
+	bool traction;
+	bool autoshift;
+	uint16_t rpm;
+	uint16_t f_press;
+	uint16_t o_press;
+	uint16_t o_temp;
+	uint16_t c_temp;
+	uint16_t f_temp;
+
+	float voltage;
+	// this needs to be replaced with a pure function
+	int v_int;
+	int v_fl;
+
+
+	launch_cnf_S launch_cnf;
+	io_state_S io;
+} veh_data_S;
+
+
+// Public Variables
+extern veh_data_S veh;

--- a/include/canbus.h
+++ b/include/canbus.h
@@ -43,6 +43,6 @@ extern uint32_t last_can_update;
 extern veh_data_S veh;
 
 // Public Functions
-void can_receive();
+extern void can_receive();
 
 #endif // CANBUS_H

--- a/include/canbus.h
+++ b/include/canbus.h
@@ -5,6 +5,7 @@
 // Interfaces Used 
 #include "mcp_can_stm.h"
 #include <inttypes.h>
+#include "VehicleData.h"
 
 #ifndef CANBUS_H
 #define CANBUS_H
@@ -33,76 +34,9 @@
 #define remote_start_st	0b00100000
 
 
-
-/*
- * data pertaining to tuning launch control from the steering wheel
- * TODO: store this in eeprom and fetch on boot, returning to default vals
- * if unset
- */
-typedef struct s_launch_cnf {
-	uint8_t rpm = 6000/100;		// default value for launch rpm
-	uint8_t th_speed = 30;		// default value for threshold speed
-} launch_cnf_S;
-
-typedef struct s_io_state {
-	/* the four switches on the bottom of the steering wheel
-	 * not counting the one in the middle
-	 * numbered from left to right
-	 */
-	bool sw1;
-	bool sw2;
-	bool sw3;
-	bool sw4;
-	/*
-	 * left and right paddle buttons
-	 */
-	bool pl;
-	bool pr;
-	/*
-	 * front top left and right buttons
-	 */
-	bool tl;
-	bool tr;
-	// lower middle button
-	bool mid;
-	/*  remote start FLAG, not IO. True when both TL and TR have been
-	 * pressed for sufficiently long
-	 * TODO: move this somewhere else maybe? idk
-	 */
-	bool remote_start;
-} io_state_S;
-
-/*
- * TYPEDEFS
- */
-typedef struct s_veh_data {
-	int8_t gear;
-	bool launch;
-	bool traction;
-	bool autoshift;
-	uint16_t rpm;
-	uint16_t f_press;
-	uint16_t o_press;
-	uint16_t o_temp;
-	uint16_t c_temp;
-	uint16_t f_temp;
-
-	float voltage;
-	// this needs to be replaced with a pure function
-	int v_int;
-	int v_fl;
-
-
-	launch_cnf_S launch_cnf;
-	io_state_S io;
-} veh_data_S;
-
-
-
-// External Variables
-extern veh_data_S veh;
+// External Data
 extern uint32_t last_can_update;
-
+extern veh_data_S veh;
 
 // Public Functions
 void can_receive();

--- a/include/canbus.h
+++ b/include/canbus.h
@@ -2,17 +2,21 @@
  * CANBus.h
  */
 
+#ifndef CANBUS_H
+#define CANBUS_H
+
 // Interfaces Used 
 #include "mcp_can_stm.h"
 #include <inttypes.h>
 #include "VehicleData.h"
 
-#ifndef CANBUS_H
-#define CANBUS_H
 
 /*
  * MACROS
  */
+
+#define MCP_CS PB12
+#define MCP_INT PB11
 
 #define can_timeout		5000		// time without CAN message before error occurs (ms)
 #define transmit_ID		0xA0		// CAN Bus transmit ID (messages will be sent with this ID)

--- a/include/main.h
+++ b/include/main.h
@@ -6,10 +6,12 @@
 #include <SPI.h>
 #include <Wire.h>
 #include <inttypes.h>
-// #include "VehicleData.h"
+#include "VehicleData.h"
 #include "shiftlights.h"
 #include "canbus.h"
+#include <FT_NHD_43RTP_SHIELD.h>
 #include "screen.h"
+
 
 
 // pin that is connected to rst
@@ -56,7 +58,4 @@ void get_inputs(uint8_t&, uint8_t&);
 // External Variables
 //TODO move all CAN stuff out of main and then delete this variable
 extern MCP_CAN CAN;
-extern FT800IMPL_SPI FTIMPL;
-extern sTagXY sTagxy;
-extern uint32_t touch_matrix [6];
 #endif // MAIN_H

--- a/include/main.h
+++ b/include/main.h
@@ -6,6 +6,7 @@
 #include <SPI.h>
 #include <Wire.h>
 #include <inttypes.h>
+// #include "VehicleData.h"
 #include "shiftlights.h"
 #include "canbus.h"
 #include "screen.h"

--- a/include/screen.h
+++ b/include/screen.h
@@ -5,13 +5,12 @@
 #include <inttypes.h>
 #include <FT_NHD_43RTP_SHIELD.h>
 #include "shiftlights.h"
+#include "VehicleData.h"
 
 /*
  * MACROS
  */
 
-#define MCP_CS PB12
-#define MCP_INT PB11
 #define SCR_CS_PIN PA0
 #define RAM_FONTS_MICROSS 0
 
@@ -22,421 +21,41 @@ static PROGMEM prog_uchar FONTS_MICROSS[] = {
 	#include "FONTS_MICROSS.h"
 };
 
-// define screen object
-FT800IMPL_SPI FTImpl(SCR_CS_PIN,FT_PDN_PIN,FT_INT_PIN);
-
-// touchscreen object
-sTagXY sTagxy;
 
 // touchscreen calibration for orange wheel
-uint32_t touch_matrix [6] = {32439, 4294966806, 4294236873, 4294966575, 4294947195, 18508876};
+extern uint32_t touch_matrix [];
+
 
 // warning defs
-int warning = -1;
-char warnings [8][20] = {"No Conn.", "Low Oil Press.", "Low Fuel Press.", "Low Batt. Volt.", "High Cool. Temp.", "High Oil Temp",
-						"Low AFR", "High AFR"};
-int last_warn = -1;
-uint8_t dismissed = 0;
+typedef struct s_warning {
+	int16_t current = -1;
+	int16_t last = -1;
+	uint8_t dismissed = 0;
+
+	char warnings[8][20] = {"No Conn.", "Low Oil Press.", "Low Fuel Press.", "Low Batt. Volt.", "High Cool. Temp.", "High Oil Temp",
+							"Low AFR", "High AFR"};
+} warning_S;
+
 
 
 // Function Prototypes 
-void calibrate_display();
-void common_display();
-void error_overlay();
-void main_display();
-void launch_display();
-void diag_display(bool, bool, bool);
-bool boot_display();
-bool check_display();
+// TODO: Split into public and private
+extern void calibrate_display();
+extern void common_display();
+extern void error_overlay();
+extern void main_display();
+extern void launch_display();
+extern void diag_display(bool, bool, bool);
+extern bool boot_display();
+extern bool check_display();
 
 /*
- * EXTERNAL VARIABLES
+ * PUBLIC VARIABLES
  */
 
-extern ShiftLights shift_lights;
-
-// ---------------------------------- Helper Functions ----------------------------------
-
-/*
- * Start up the screen
- */
-bool boot_display(){
-	uint32_t chipid;
-	FTImpl.Init(FT_DISPLAY_RESOLUTION, 0);		//configure the display to the WQVGA
-	chipid = FTImpl.Read32(FT_ROM_CHIPID);
-	/* Identify the chip */
-	int counter = 0;
-	while(FT800_CHIPID != chipid){
-		shift_lights.SetAllColor(0xFF0000);
-//		Serial.print("Error in chip id read ");
-//		Serial.println(chipid,HEX);
-		FTImpl.Init(FT_DISPLAY_RESOLUTION, 0);
-		//delay(20);
-		chipid = FTImpl.Read32(FT_ROM_CHIPID);
-		counter++;
-		if (counter == 10){
-			return 1;
-		}
-	}
-
-	shift_lights.Clear();
-
-	/* Set the Display & audio pins */
-	FTImpl.SetDisplayEnablePin(FT_DISPENABLE_PIN);
-	FTImpl.SetAudioEnablePin(FT_AUDIOENABLE_PIN);
-
-	// turn the screen on and the amplifier off
-	FTImpl.DisplayOn();
-	FTImpl.AudioOff();
-
-	// set touchscreen calibration values to what we've acquired
-	FTImpl.Write32(REG_TOUCH_TRANSFORM_A, touch_matrix[0]);
-	FTImpl.Write32(REG_TOUCH_TRANSFORM_B, touch_matrix[1]);
-	FTImpl.Write32(REG_TOUCH_TRANSFORM_C, touch_matrix[2]);
-	FTImpl.Write32(REG_TOUCH_TRANSFORM_D, touch_matrix[3]);
-	FTImpl.Write32(REG_TOUCH_TRANSFORM_E, touch_matrix[4]);
-	FTImpl.Write32(REG_TOUCH_TRANSFORM_F, touch_matrix[5]);
-	FTImpl.Cmd_SetMatrix();
-
-	// prepare the font to be displayed (gear and rpm)
-	FTImpl.DLStart();
-	FTImpl.Cmd_Inflate(RAM_FONTS_MICROSS);
-	FTImpl.WriteCmdfromflash(FONTS_MICROSS, sizeof(FONTS_MICROSS));
-	FTImpl.DLEnd();
-	FTImpl.DLStart();
-	FTImpl.BitmapHandle(0);
-	FTImpl.BitmapSource(-178412);
-	FTImpl.BitmapLayout(FT_L4, 40, 93);
-	FTImpl.BitmapSize(FT_NEAREST, FT_BORDER, FT_BORDER, 80, 93);
-	FTImpl.Cmd_SetFont(0, 0);
-	FTImpl.DLEnd();
-	FTImpl.Finish();
-
-	return 0;
-}
-
-
-/*
- * Verify successful connection to screen by reading the FT800 chip
- * id from its memory and comparing with the known good value
-*/
-bool check_display(){
-	uint32_t chipid;
-	chipid = FTImpl.Read32(FT_ROM_CHIPID);
-	/* Identify the chip */
-	if(FT800_CHIPID != chipid) return 0;
-
-	return 1;
-}
-
-
-/*
- * If called, prompts the user to click on 6 points on the screen.
- * Generates calibration data
-*/
-void calibrate_display(){
-	FTImpl.DLStart();
-
-	FTImpl.Cmd_Calibrate(0);
-
-	FTImpl.DLEnd();
-	FTImpl.Finish();
-
-	touch_matrix[0] = FTImpl.Read32(REG_TOUCH_TRANSFORM_A);
-	touch_matrix[1] = FTImpl.Read32(REG_TOUCH_TRANSFORM_B);
-	touch_matrix[2] = FTImpl.Read32(REG_TOUCH_TRANSFORM_C);
-	touch_matrix[3] = FTImpl.Read32(REG_TOUCH_TRANSFORM_D);
-	touch_matrix[4] = FTImpl.Read32(REG_TOUCH_TRANSFORM_E);
-	touch_matrix[5] = FTImpl.Read32(REG_TOUCH_TRANSFORM_F);
-}
-
-
-// Pill Maker
-void make_pill(int x, int y)		// coords are in the form {x, y}
-{
-	FTImpl.PointSize(246);
-	FTImpl.Begin(FT_POINTS);
-	FTImpl.Vertex2ii(x - 25, y, 1, 0);
-	FTImpl.Vertex2ii(x + 25, y, 1, 0);
-	FTImpl.End();
-	FTImpl.Begin(FT_RECTS);
-	FTImpl.Vertex2ii(x - 25, y - 15, 0, 0);
-	FTImpl.Vertex2ii(x + 25, y + 15, 0, 0);
-	FTImpl.End();
-}
-
-void error_overlay(){
-	FTImpl.Begin(FT_RECTS);
-
-	FTImpl.ColorA(64);
-	FTImpl.ColorRGB(71, 71, 71);
-	FTImpl.Vertex2ii(0, 0, 0, 0);
-	FTImpl.Vertex2ii(480, 272, 0, 0);
-
-	FTImpl.ColorA(255);
-	FTImpl.ColorRGB(0, 0, 0);
-	FTImpl.Vertex2ii(50, 50, 0, 0);
-	FTImpl.Vertex2ii(433, 222, 0, 0);
-	FTImpl.End();
-
-	FTImpl.ColorRGB(255, 0, 0);
-	FTImpl.Cmd_Text(240, 136, 30, FT_OPT_CENTER, warnings[warning]);
-}
-
-
-void main_display(){
-	uint32_t col = 0;
-	int x = 0;
-	int y = 0;
-
-	// Top Left Pill (Battery Voltage)
-	col = (veh.voltage > 12) ? 0x00FF00 : 0x0000FF;
-	col = (veh.voltage <= 9) ? 0xFF0000 : col;
-
-	x = 45;
-	y = 105;
-	FTImpl.ColorRGB(0xFFFFFF);
-	FTImpl.Cmd_Text(x, y-25, 26, FT_OPT_CENTER, "B_Volt");
-	FTImpl.ColorRGB(col);
-	make_pill(x, y);
-	FTImpl.ColorRGB(0, 0, 0);
-	FTImpl.Cmd_Number(x-15, y, 28, FT_OPT_CENTER, veh.v_int);
-	FTImpl.Cmd_Text(x, y, 28, FT_OPT_CENTER, ".");
-	FTImpl.Cmd_Number(x+7, y, 28, FT_OPT_CENTER, veh.v_fl);
-	FTImpl.Cmd_Text(x+27, y, 28, FT_OPT_CENTER, "V");
-
-
-	// Top Right Pill (Coolant Temp)
-	col = (veh.c_temp > 100) ? 0xFF0000 : 0x00FF00;
-	col = (veh.c_temp <= 80) ? 0x0000FF : col;
-	col = (veh.c_temp <= 40) ? 0xFF0000 : col;
-
-	x = 435;
-	y = 105;
-
-	FTImpl.ColorRGB(0xFFFFFF);
-	FTImpl.Cmd_Text(x, y-25, 26, FT_OPT_CENTER, "C_Temp");
-	FTImpl.ColorRGB(col);
-	make_pill(x, y);
-	FTImpl.ColorRGB(0, 0, 0);
-	FTImpl.Cmd_Number(x-15, y, 28, FT_OPT_SIGNED | FT_OPT_CENTER, veh.c_temp);
-	FTImpl.Cmd_Text(x+27, y, 28, FT_OPT_CENTER, "C");
-	FTImpl.Cmd_Text(x+17, y-10, 26, FT_OPT_CENTER, "o");
-
-
-	// Middle Left Pill (Oil Pressure)
-	x = 45;
-	y = 170;
-	col = (veh.o_press > 380) ? 0x00FF00 : 0x0000FF;
-	col = (veh.o_press <= 100) ? 0xFF0000 : col;
-
-	FTImpl.ColorRGB(0xFFFFFF);
-	FTImpl.Cmd_Text(x, y-25, 26, FT_OPT_CENTER, "O_Press");
-	FTImpl.ColorRGB(col);
-	make_pill(x, y);
-	FTImpl.ColorRGB(0, 0, 0);
-	FTImpl.Cmd_Number(x-15, y, 28, FT_OPT_SIGNED | FT_OPT_CENTER, veh.o_press);
-	FTImpl.Cmd_Text(x+27, y, 28, FT_OPT_CENTER, "C");
-	FTImpl.Cmd_Text(x+17, y-8, 26, FT_OPT_CENTER, "o");
-
-
-	// Middle Right Pill (Fuel Pressure)
-	col = (veh.f_press > 380) ? 0x00FF00 : 0x0000FF;
-	col = (veh.f_press <= 100) ? 0xFF0000 : col;
-
-	x = 435;
-	y = 170;
-	FTImpl.ColorRGB(0xFFFFFF);
-	FTImpl.Cmd_Text(x, y-25, 26, FT_OPT_CENTER, "F_Press");
-	FTImpl.ColorRGB(col);
-	make_pill(x, y);
-	FTImpl.ColorRGB(0, 0, 0);
-	FTImpl.Cmd_Number(x-21, y, 28, FT_OPT_SIGNED | FT_OPT_CENTER, veh.f_press);
-	FTImpl.Cmd_Text(x+18, y, 28, FT_OPT_CENTER, "kPa");
-
-
-	// Bottom Left Pill (Oil Temp)
-	col = (veh.o_temp > 115) ? 0xFF0000 : 0x00FF00;
-	col = (veh.o_temp <= 80) ? 0x0000FF : col;
-	col = (veh.o_temp <= 40) ? 0xFF0000 : col;
-
-	x = 45;
-	y = 235;
-
-	FTImpl.ColorRGB(0xFFFFFF);
-	FTImpl.Cmd_Text(x, y-25, 26, FT_OPT_CENTER, "O_Temp");
-	FTImpl.ColorRGB(col);
-	make_pill(x, y);
-	FTImpl.ColorRGB(0, 0, 0);
-	FTImpl.Cmd_Number(x-15, y, 28, FT_OPT_SIGNED | FT_OPT_CENTER, veh.o_temp);
-	FTImpl.Cmd_Text(x+27, y, 28, FT_OPT_CENTER, "C");
-	FTImpl.Cmd_Text(x+17, y-8, 26, FT_OPT_CENTER, "o");
-
-
-	// Bottom Right Pill (Fuel Temp)
-	x = 435;
-	y = 235;
-	col = (veh.f_temp > 380) ? 0x00FF00 : 0x0000FF;
-	col = (veh.f_temp <= 100) ? 0xFF0000 : col;
-
-	FTImpl.ColorRGB(0xFFFFFF);
-	FTImpl.Cmd_Text(x, y-25, 26, FT_OPT_CENTER, "F_Temp");
-	FTImpl.ColorRGB(col);
-	make_pill(x, y);
-	FTImpl.ColorRGB(0, 0, 0);
-	FTImpl.Cmd_Number(x-15, y, 28, FT_OPT_SIGNED | FT_OPT_CENTER, veh.f_temp);
-	FTImpl.Cmd_Text(x+27, y, 28, FT_OPT_CENTER, "C");
-	FTImpl.Cmd_Text(x+17, y-8, 26, FT_OPT_CENTER, "o");
-
-	FTImpl.ColorRGB(255, 255, 255);
-	FTImpl.Cmd_Number(240, 45, 0, FT_OPT_CENTER, veh.rpm);
-
-	const char * gears [6]= {"N", "1", "2", "3", "4", "5"};
-
-	if(veh.gear > -1 && veh.gear < 7){
-		FTImpl.Cmd_Text(240, 156, 0, FT_OPT_CENTER, gears[veh.gear]);
-	} else {
-		FTImpl.Cmd_Text(240, 156, 0, FT_OPT_CENTER, "?");
-	}
-
-	common_display();
-}
-
-// display elements that are shown on most pages
-void common_display()
-{
-	FTImpl.PointSize(160);
-	FTImpl.Begin(FT_POINTS);
-	
-	uint32_t col;
-
-	col = (veh.io.tl) ? 0x00FF00 : 0xFFFFFF;
-	FTImpl.ColorRGB(col);
-	FTImpl.Vertex2ii(20, 35, 1, 0);
-
-	col = (veh.io.tl) ? 0x00FF00 : 0xFFFFFF;
-	FTImpl.ColorRGB(col);
-	FTImpl.Vertex2ii(445, 35, 1, 0);
-
-	col = (veh.io.tl) ? 0x00FF00 : 0xFFFFFF;
-	FTImpl.ColorRGB(col);
-	FTImpl.Vertex2ii(150, 255, 1, 0);
-
-	col = (veh.io.tl) ? 0x00FF00 : 0xFFFFFF;
-	FTImpl.ColorRGB(col);
-	FTImpl.Vertex2ii(210, 255, 1, 0);
-
-	col = (veh.io.tl) ? 0x00FF00 : 0xFFFFFF;
-	FTImpl.ColorRGB(col);
-	FTImpl.Vertex2ii(270, 255, 1, 0);
-	FTImpl.End();
-
-
-	FTImpl.ColorRGB(0xFFFFFF);
-	FTImpl.Cmd_Text(20, 15, 21, FT_OPT_CENTER, "DRS");
-
-	FTImpl.ColorRGB(0xFFFFF);
-	FTImpl.Cmd_Text(445, 15, 21, FT_OPT_CENTER, "LC");
-
-	FTImpl.ColorRGB(0xFFFFFF);
-	FTImpl.Cmd_Text(150, 235, 21, FT_OPT_CENTER, "LC");
-
-	FTImpl.ColorRGB(0xFFFFFF);
-	FTImpl.Cmd_Text(210, 235, 21, FT_OPT_CENTER, "AS");
-
-	FTImpl.ColorRGB(0xFFFFFF);
-	FTImpl.Cmd_Text(270, 237, 21, FT_OPT_CENTER, "CTRL");
-
-
-	FTImpl.ColorRGB(0xFFFFFF);
-	FTImpl.Cmd_Text(330, 237, 21, FT_OPT_CENTER, "WC");
-
-	const char *d_w = !veh.io.sw4 ? "D" : "W";
-	FTImpl.Cmd_Text(330, 255, 28, FT_OPT_CENTER, d_w);
-
-
-	if(veh.io.remote_start){
-		FTImpl.ColorRGB(255, 0, 0);
-		FTImpl.Cmd_Text(240, 208, 27, FT_OPT_CENTER, "IGN");
-	}
-}
-
-void launch_display(){
-
-	FTImpl.ColorRGB(255, 255, 255);
-	FTImpl.Begin(FT_LINES);
-	FTImpl.Vertex2ii(160, 0, 0, 0);
-	FTImpl.Vertex2ii(160, 272, 0, 0);
-	FTImpl.End();
-
-	FTImpl.Begin(FT_LINES);
-	FTImpl.Vertex2ii(320, 0, 0, 0);
-	FTImpl.Vertex2ii(320, 272, 0, 0);
-	FTImpl.End();
-
-	FTImpl.Cmd_Text(80, 15, 28, FT_OPT_CENTER, "Best");
-	FTImpl.Cmd_Text(240, 15, 28, FT_OPT_CENTER, "Last");
-	FTImpl.Cmd_Text(240, 32, 28, FT_OPT_CENTER, "Launch");
-	FTImpl.Cmd_Text(400, 15, 28, FT_OPT_CENTER, "Current");
-
-	FTImpl.Cmd_Text(348, 35, 23, FT_OPT_CENTER, "RPM:");
-	FTImpl.Cmd_Number(400, 55, 30, FT_OPT_CENTER, veh.launch_cnf.rpm*100);
-	FTImpl.Tag(4);
-	FTImpl.Cmd_Button(340, 70, 48, 48, 27, 0, "-");
-	FTImpl.Tag(5);
-	FTImpl.Cmd_Button(410, 70, 48, 48, 27, 0, "+");
-
-	FTImpl.Cmd_Text(355, 133, 23, FT_OPT_CENTER, "Thresh:");
-	FTImpl.Cmd_Number(400, 155, 30, FT_OPT_CENTER, veh.launch_cnf.th_speed);
-	FTImpl.Tag(6);
-	FTImpl.Cmd_Button(335, 170, 48, 48, 27, 0, "-");
-	FTImpl.Tag(7);
-	FTImpl.Cmd_Button(414, 170, 48, 48, 27, 0, "+");
-	FTImpl.DLEnd();
-
-
-	common_display();
-}
-
-
-void diag_display(bool diag_shift, bool diag_fuel_st, bool diag_rst){
-	FTImpl.Cmd_Text(240, 32, 28, FT_OPT_CENTER, "Diagnostics");
-
-	FTImpl.Begin(FT_POINTS);
-	FTImpl.PointSize(600);
-
-	FTImpl.Tag(1);
-	if(diag_shift) FTImpl.ColorRGB(0, 255, 0);
-	FTImpl.Vertex2ii(100, 145, 0, 0);
-	FTImpl.ColorRGB(255, 255, 255);
-
-	FTImpl.Tag(2);
-	if(diag_fuel_st) FTImpl.ColorRGB(0, 255, 0);
-	FTImpl.Vertex2ii(230, 145, 0, 0);
-	FTImpl.ColorRGB(255, 255, 255);
-
-	FTImpl.Tag(3);
-	if(diag_rst) FTImpl.ColorRGB(0, 255, 0);
-	FTImpl.Vertex2ii(360, 145, 0, 0);
-	FTImpl.ColorRGB(255, 255, 255);
-
-	FTImpl.End();
-
-
-	if(diag_shift) FTImpl.ColorRGB(0, 255, 0);
-	FTImpl.Cmd_Text(100, 90, 28, FT_OPT_CENTER, "Shift Lights");
-	FTImpl.ColorRGB(255, 255, 255);
-
-	if(diag_fuel_st) FTImpl.ColorRGB(0, 255, 0);
-	FTImpl.Cmd_Text(230, 90, 28, FT_OPT_CENTER, "Fuel Pump");
-	FTImpl.ColorRGB(255, 255, 255);
-
-	if(diag_rst) FTImpl.ColorRGB(0, 255, 0);
-	FTImpl.Cmd_Text(360, 90, 28, FT_OPT_CENTER, "Reset MCU");
-	FTImpl.ColorRGB(255, 255, 255);
-
-
-	common_display();
-}
+extern ShiftLights shift_lights;		// bring in shiftligts object so we can control them
+extern FT800IMPL_SPI FTImpl;			// define screen obj
+extern sTagXY sTagxy;					// define touchscreen obj
+extern warning_S warning;				// define the warning struct above
 
 #endif // SCREEN_H

--- a/lib/FTDI_FT800/FT_NHD_43RTP_SHIELD.h
+++ b/lib/FTDI_FT800/FT_NHD_43RTP_SHIELD.h
@@ -67,9 +67,11 @@ typedef PROGMEM const unsigned long prog_uint32_t;
 #define FT_SD_CSPIN 			PA1
 
 
+extern SPIClass SPI_2;
+
 /* Hardware specific include files */
 #include "hardware/FT800/FT800.h"
-#include "libraries/FT_SD/FT_SD.h"
+// #include "libraries/FT_SD/FT_SD.h"
 //#include "libraries/FT_RTC/FT_RTC.h"
 #include "libraries/FT_GC/FT_Transport_SPI/FT_Transport_SPI.h"
 #include "libraries/FT_GC/FT_GC.h"

--- a/lib/FTDI_FT800/hardware/FT800/FT800.h
+++ b/lib/FTDI_FT800/hardware/FT800/FT800.h
@@ -539,7 +539,8 @@
 #define RESTORE_CONTEXT() ((35UL<<24))
 #define RETURN() ((36UL<<24))
 #define MACRO(m) ((37UL<<24)|(((m)&1UL)<<0))
-#define DISPLAY() ((0UL<<24))
+// commenting this out because we don't use it and it throws warnings
+// #define DISPLAY() ((0UL<<24))
 
 #endif /* _FT800_H_ */
 

--- a/src/VehicleData.cpp
+++ b/src/VehicleData.cpp
@@ -1,0 +1,3 @@
+#include "VehicleData.h"
+
+veh_data_S veh;

--- a/src/canbus.cpp
+++ b/src/canbus.cpp
@@ -4,9 +4,6 @@
 /*
  * PUBLIC DATA
  */
-veh_data_S veh;
-// io_state_S io;
-// launch_cnf_S launch;
 
 // CAN bus def
 MCP_CAN CAN;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -81,9 +81,6 @@ void loop(){
 			warning.current = 0;
 		}
 
-		veh.v_int = veh.voltage;
-		veh.v_fl = (float)((veh.voltage - veh.v_int)*10);
-
 		shift_lights.Update(veh.gear, veh.rpm);
 		c_time = millis();
 	}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,6 +1,7 @@
 #include "main.h"
 
 ShiftLights shift_lights = ShiftLights(kSLPin, kSLCount, kSLBrightness);
+SPIClass SPI_2(2);
 
 void setup(){
 	Serial.begin(115200);
@@ -46,7 +47,7 @@ void setup(){
 */
 
 	if(!(CAN_OK == CAN.begin(CAN_1000KBPS, MCP_CS))){
-		warning = 0;
+		warning.current = 0;
 	}
 
 	/*
@@ -74,10 +75,10 @@ void loop(){
 		if(CAN_MSGAVAIL == CAN.checkReceive()){
 			can_receive();
 			last_can_update = c_time;
-			warning = -1;
+			warning.current = -1;
 		}
 		else if((c_time - last_can_update > can_timeout)){
-			warning = 0;
+			warning.current = 0;
 		}
 
 		veh.v_int = veh.voltage;
@@ -167,7 +168,7 @@ void loop(){
 			main_display();
 		}
 
-		if((warning != -1) && !(dismissed & (warning + 1)) && !veh.io.sw3){
+		if((warning.current != -1) && !(warning.dismissed & (warning.current + 1)) && !veh.io.sw3){
 			error_overlay();
 		}
 
@@ -215,17 +216,17 @@ void get_inputs(uint8_t &status1, uint8_t &status2){
 
 
 	// dismiss the current warning if either tl or tr is pressed, intercept their respective functions
-	if((veh.io.tl || veh.io.tr) && warning != -1){
-		if(!(dismissed & (warning+1))){
-			dismissed = dismissed | (warning+1);
-			warning = -1;
+	if((veh.io.tl || veh.io.tr) && warning.current != -1){
+		if(!(warning.dismissed & (warning.current+1))){
+			warning.dismissed = warning.dismissed | (warning.current+1);
+			warning.current = -1;
 			veh.io.tl = 0;
 			veh.io.tr = 0;
 		}
 	}
 
 	// un-dismiss the warnings if the middle button is pressed
-	dismissed = veh.io.mid ? 0 : dismissed;
+	warning.dismissed = veh.io.mid ? 0 : warning.dismissed;
 
 	// create the status bitfields
 	status1 = 0;

--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -1,0 +1,395 @@
+#include "screen.h"
+#include "VehicleData.h"
+
+
+FT800IMPL_SPI FTImpl(SCR_CS_PIN,FT_PDN_PIN,FT_INT_PIN);
+sTagXY sTagxy;
+warning_S warning;
+
+uint32_t touch_matrix [6] = {32439, 4294966806, 4294236873, 4294966575, 4294947195, 18508876};
+
+
+
+// ---------------------------------- Helper Functions ----------------------------------
+
+/*
+ * Start up the screen
+ */
+bool boot_display(){
+	uint32_t chipid;
+	FTImpl.Init(FT_DISPLAY_RESOLUTION, 0);		//configure the display to the WQVGA
+	chipid = FTImpl.Read32(FT_ROM_CHIPID);
+	/* Identify the chip */
+	int counter = 0;
+	while(FT800_CHIPID != chipid){
+		shift_lights.SetAllColor(0xFF0000);
+//		Serial.print("Error in chip id read ");
+//		Serial.println(chipid,HEX);
+		FTImpl.Init(FT_DISPLAY_RESOLUTION, 0);
+		//delay(20);
+		chipid = FTImpl.Read32(FT_ROM_CHIPID);
+		counter++;
+		if (counter == 10){
+			return 1;
+		}
+	}
+
+	shift_lights.Clear();
+
+	/* Set the Display & audio pins */
+	FTImpl.SetDisplayEnablePin(FT_DISPENABLE_PIN);
+	FTImpl.SetAudioEnablePin(FT_AUDIOENABLE_PIN);
+
+	// turn the screen on and the amplifier off
+	FTImpl.DisplayOn();
+	FTImpl.AudioOff();
+
+	// set touchscreen calibration values to what we've acquired
+	FTImpl.Write32(REG_TOUCH_TRANSFORM_A, touch_matrix[0]);
+	FTImpl.Write32(REG_TOUCH_TRANSFORM_B, touch_matrix[1]);
+	FTImpl.Write32(REG_TOUCH_TRANSFORM_C, touch_matrix[2]);
+	FTImpl.Write32(REG_TOUCH_TRANSFORM_D, touch_matrix[3]);
+	FTImpl.Write32(REG_TOUCH_TRANSFORM_E, touch_matrix[4]);
+	FTImpl.Write32(REG_TOUCH_TRANSFORM_F, touch_matrix[5]);
+	FTImpl.Cmd_SetMatrix();
+
+	// prepare the font to be displayed (gear and rpm)
+	FTImpl.DLStart();
+	FTImpl.Cmd_Inflate(RAM_FONTS_MICROSS);
+	FTImpl.WriteCmdfromflash(FONTS_MICROSS, sizeof(FONTS_MICROSS));
+	FTImpl.DLEnd();
+	FTImpl.DLStart();
+	FTImpl.BitmapHandle(0);
+	FTImpl.BitmapSource(-178412);
+	FTImpl.BitmapLayout(FT_L4, 40, 93);
+	FTImpl.BitmapSize(FT_NEAREST, FT_BORDER, FT_BORDER, 80, 93);
+	FTImpl.Cmd_SetFont(0, 0);
+	FTImpl.DLEnd();
+	FTImpl.Finish();
+
+	return 0;
+}
+
+
+/*
+ * Verify successful connection to screen by reading the FT800 chip
+ * id from its memory and comparing with the known good value
+*/
+bool check_display(){
+	uint32_t chipid;
+	chipid = FTImpl.Read32(FT_ROM_CHIPID);
+	/* Identify the chip */
+	if(FT800_CHIPID != chipid) return 0;
+
+	return 1;
+}
+
+
+/*
+ * If called, prompts the user to click on 6 points on the screen.
+ * Generates calibration data
+*/
+void calibrate_display(){
+	FTImpl.DLStart();
+
+	FTImpl.Cmd_Calibrate(0);
+
+	FTImpl.DLEnd();
+	FTImpl.Finish();
+
+	touch_matrix[0] = FTImpl.Read32(REG_TOUCH_TRANSFORM_A);
+	touch_matrix[1] = FTImpl.Read32(REG_TOUCH_TRANSFORM_B);
+	touch_matrix[2] = FTImpl.Read32(REG_TOUCH_TRANSFORM_C);
+	touch_matrix[3] = FTImpl.Read32(REG_TOUCH_TRANSFORM_D);
+	touch_matrix[4] = FTImpl.Read32(REG_TOUCH_TRANSFORM_E);
+	touch_matrix[5] = FTImpl.Read32(REG_TOUCH_TRANSFORM_F);
+}
+
+
+// Pill Maker
+void make_pill(int x, int y)		// coords are in the form {x, y}
+{
+	FTImpl.PointSize(246);
+	FTImpl.Begin(FT_POINTS);
+	FTImpl.Vertex2ii(x - 25, y, 1, 0);
+	FTImpl.Vertex2ii(x + 25, y, 1, 0);
+	FTImpl.End();
+	FTImpl.Begin(FT_RECTS);
+	FTImpl.Vertex2ii(x - 25, y - 15, 0, 0);
+	FTImpl.Vertex2ii(x + 25, y + 15, 0, 0);
+	FTImpl.End();
+}
+
+void error_overlay(){
+	FTImpl.Begin(FT_RECTS);
+
+	FTImpl.ColorA(64);
+	FTImpl.ColorRGB(71, 71, 71);
+	FTImpl.Vertex2ii(0, 0, 0, 0);
+	FTImpl.Vertex2ii(480, 272, 0, 0);
+
+	FTImpl.ColorA(255);
+	FTImpl.ColorRGB(0, 0, 0);
+	FTImpl.Vertex2ii(50, 50, 0, 0);
+	FTImpl.Vertex2ii(433, 222, 0, 0);
+	FTImpl.End();
+
+	FTImpl.ColorRGB(255, 0, 0);
+	FTImpl.Cmd_Text(240, 136, 30, FT_OPT_CENTER, warning.warnings[warning.current]);
+}
+
+
+void main_display(){
+	uint32_t col = 0;
+	int x = 0;
+	int y = 0;
+
+	// Top Left Pill (Battery Voltage)
+	col = (veh.voltage > 12) ? 0x00FF00 : 0x0000FF;
+	col = (veh.voltage <= 9) ? 0xFF0000 : col;
+
+	x = 45;
+	y = 105;
+	FTImpl.ColorRGB(0xFFFFFF);
+	FTImpl.Cmd_Text(x, y-25, 26, FT_OPT_CENTER, "B_Volt");
+	FTImpl.ColorRGB(col);
+	make_pill(x, y);
+	FTImpl.ColorRGB(0, 0, 0);
+	FTImpl.Cmd_Number(x-15, y, 28, FT_OPT_CENTER, veh.v_int);
+	FTImpl.Cmd_Text(x, y, 28, FT_OPT_CENTER, ".");
+	FTImpl.Cmd_Number(x+7, y, 28, FT_OPT_CENTER, veh.v_fl);
+	FTImpl.Cmd_Text(x+27, y, 28, FT_OPT_CENTER, "V");
+
+
+	// Top Right Pill (Coolant Temp)
+	col = (veh.c_temp > 100) ? 0xFF0000 : 0x00FF00;
+	col = (veh.c_temp <= 80) ? 0x0000FF : col;
+	col = (veh.c_temp <= 40) ? 0xFF0000 : col;
+
+	x = 435;
+	y = 105;
+
+	FTImpl.ColorRGB(0xFFFFFF);
+	FTImpl.Cmd_Text(x, y-25, 26, FT_OPT_CENTER, "C_Temp");
+	FTImpl.ColorRGB(col);
+	make_pill(x, y);
+	FTImpl.ColorRGB(0, 0, 0);
+	FTImpl.Cmd_Number(x-15, y, 28, FT_OPT_SIGNED | FT_OPT_CENTER, veh.c_temp);
+	FTImpl.Cmd_Text(x+27, y, 28, FT_OPT_CENTER, "C");
+	FTImpl.Cmd_Text(x+17, y-10, 26, FT_OPT_CENTER, "o");
+
+
+	// Middle Left Pill (Oil Pressure)
+	x = 45;
+	y = 170;
+	col = (veh.o_press > 380) ? 0x00FF00 : 0x0000FF;
+	col = (veh.o_press <= 100) ? 0xFF0000 : col;
+
+	FTImpl.ColorRGB(0xFFFFFF);
+	FTImpl.Cmd_Text(x, y-25, 26, FT_OPT_CENTER, "O_Press");
+	FTImpl.ColorRGB(col);
+	make_pill(x, y);
+	FTImpl.ColorRGB(0, 0, 0);
+	FTImpl.Cmd_Number(x-15, y, 28, FT_OPT_SIGNED | FT_OPT_CENTER, veh.o_press);
+	FTImpl.Cmd_Text(x+27, y, 28, FT_OPT_CENTER, "C");
+	FTImpl.Cmd_Text(x+17, y-8, 26, FT_OPT_CENTER, "o");
+
+
+	// Middle Right Pill (Fuel Pressure)
+	col = (veh.f_press > 380) ? 0x00FF00 : 0x0000FF;
+	col = (veh.f_press <= 100) ? 0xFF0000 : col;
+
+	x = 435;
+	y = 170;
+	FTImpl.ColorRGB(0xFFFFFF);
+	FTImpl.Cmd_Text(x, y-25, 26, FT_OPT_CENTER, "F_Press");
+	FTImpl.ColorRGB(col);
+	make_pill(x, y);
+	FTImpl.ColorRGB(0, 0, 0);
+	FTImpl.Cmd_Number(x-21, y, 28, FT_OPT_SIGNED | FT_OPT_CENTER, veh.f_press);
+	FTImpl.Cmd_Text(x+18, y, 28, FT_OPT_CENTER, "kPa");
+
+
+	// Bottom Left Pill (Oil Temp)
+	col = (veh.o_temp > 115) ? 0xFF0000 : 0x00FF00;
+	col = (veh.o_temp <= 80) ? 0x0000FF : col;
+	col = (veh.o_temp <= 40) ? 0xFF0000 : col;
+
+	x = 45;
+	y = 235;
+
+	FTImpl.ColorRGB(0xFFFFFF);
+	FTImpl.Cmd_Text(x, y-25, 26, FT_OPT_CENTER, "O_Temp");
+	FTImpl.ColorRGB(col);
+	make_pill(x, y);
+	FTImpl.ColorRGB(0, 0, 0);
+	FTImpl.Cmd_Number(x-15, y, 28, FT_OPT_SIGNED | FT_OPT_CENTER, veh.o_temp);
+	FTImpl.Cmd_Text(x+27, y, 28, FT_OPT_CENTER, "C");
+	FTImpl.Cmd_Text(x+17, y-8, 26, FT_OPT_CENTER, "o");
+
+
+	// Bottom Right Pill (Fuel Temp)
+	x = 435;
+	y = 235;
+	col = (veh.f_temp > 380) ? 0x00FF00 : 0x0000FF;
+	col = (veh.f_temp <= 100) ? 0xFF0000 : col;
+
+	FTImpl.ColorRGB(0xFFFFFF);
+	FTImpl.Cmd_Text(x, y-25, 26, FT_OPT_CENTER, "F_Temp");
+	FTImpl.ColorRGB(col);
+	make_pill(x, y);
+	FTImpl.ColorRGB(0, 0, 0);
+	FTImpl.Cmd_Number(x-15, y, 28, FT_OPT_SIGNED | FT_OPT_CENTER, veh.f_temp);
+	FTImpl.Cmd_Text(x+27, y, 28, FT_OPT_CENTER, "C");
+	FTImpl.Cmd_Text(x+17, y-8, 26, FT_OPT_CENTER, "o");
+
+	FTImpl.ColorRGB(255, 255, 255);
+	FTImpl.Cmd_Number(240, 45, 0, FT_OPT_CENTER, veh.rpm);
+
+	const char * gears [6]= {"N", "1", "2", "3", "4", "5"};
+
+	if(veh.gear > -1 && veh.gear < 7){
+		FTImpl.Cmd_Text(240, 156, 0, FT_OPT_CENTER, gears[veh.gear]);
+	} else {
+		FTImpl.Cmd_Text(240, 156, 0, FT_OPT_CENTER, "?");
+	}
+
+	common_display();
+}
+
+// display elements that are shown on most pages
+void common_display()
+{
+	FTImpl.PointSize(160);
+	FTImpl.Begin(FT_POINTS);
+	
+	uint32_t col;
+
+	col = (veh.io.tl) ? 0x00FF00 : 0xFFFFFF;
+	FTImpl.ColorRGB(col);
+	FTImpl.Vertex2ii(20, 35, 1, 0);
+
+	col = (veh.io.tl) ? 0x00FF00 : 0xFFFFFF;
+	FTImpl.ColorRGB(col);
+	FTImpl.Vertex2ii(445, 35, 1, 0);
+
+	col = (veh.io.tl) ? 0x00FF00 : 0xFFFFFF;
+	FTImpl.ColorRGB(col);
+	FTImpl.Vertex2ii(150, 255, 1, 0);
+
+	col = (veh.io.tl) ? 0x00FF00 : 0xFFFFFF;
+	FTImpl.ColorRGB(col);
+	FTImpl.Vertex2ii(210, 255, 1, 0);
+
+	col = (veh.io.tl) ? 0x00FF00 : 0xFFFFFF;
+	FTImpl.ColorRGB(col);
+	FTImpl.Vertex2ii(270, 255, 1, 0);
+	FTImpl.End();
+
+
+	FTImpl.ColorRGB(0xFFFFFF);
+	FTImpl.Cmd_Text(20, 15, 21, FT_OPT_CENTER, "DRS");
+
+	FTImpl.ColorRGB(0xFFFFF);
+	FTImpl.Cmd_Text(445, 15, 21, FT_OPT_CENTER, "LC");
+
+	FTImpl.ColorRGB(0xFFFFFF);
+	FTImpl.Cmd_Text(150, 235, 21, FT_OPT_CENTER, "LC");
+
+	FTImpl.ColorRGB(0xFFFFFF);
+	FTImpl.Cmd_Text(210, 235, 21, FT_OPT_CENTER, "AS");
+
+	FTImpl.ColorRGB(0xFFFFFF);
+	FTImpl.Cmd_Text(270, 237, 21, FT_OPT_CENTER, "CTRL");
+
+
+	FTImpl.ColorRGB(0xFFFFFF);
+	FTImpl.Cmd_Text(330, 237, 21, FT_OPT_CENTER, "WC");
+
+	const char *d_w = !veh.io.sw4 ? "D" : "W";
+	FTImpl.Cmd_Text(330, 255, 28, FT_OPT_CENTER, d_w);
+
+
+	if(veh.io.remote_start){
+		FTImpl.ColorRGB(255, 0, 0);
+		FTImpl.Cmd_Text(240, 208, 27, FT_OPT_CENTER, "IGN");
+	}
+}
+
+void launch_display(){
+
+	FTImpl.ColorRGB(255, 255, 255);
+	FTImpl.Begin(FT_LINES);
+	FTImpl.Vertex2ii(160, 0, 0, 0);
+	FTImpl.Vertex2ii(160, 272, 0, 0);
+	FTImpl.End();
+
+	FTImpl.Begin(FT_LINES);
+	FTImpl.Vertex2ii(320, 0, 0, 0);
+	FTImpl.Vertex2ii(320, 272, 0, 0);
+	FTImpl.End();
+
+	FTImpl.Cmd_Text(80, 15, 28, FT_OPT_CENTER, "Best");
+	FTImpl.Cmd_Text(240, 15, 28, FT_OPT_CENTER, "Last");
+	FTImpl.Cmd_Text(240, 32, 28, FT_OPT_CENTER, "Launch");
+	FTImpl.Cmd_Text(400, 15, 28, FT_OPT_CENTER, "Current");
+
+	FTImpl.Cmd_Text(348, 35, 23, FT_OPT_CENTER, "RPM:");
+	FTImpl.Cmd_Number(400, 55, 30, FT_OPT_CENTER, veh.launch_cnf.rpm*100);
+	FTImpl.Tag(4);
+	FTImpl.Cmd_Button(340, 70, 48, 48, 27, 0, "-");
+	FTImpl.Tag(5);
+	FTImpl.Cmd_Button(410, 70, 48, 48, 27, 0, "+");
+
+	FTImpl.Cmd_Text(355, 133, 23, FT_OPT_CENTER, "Thresh:");
+	FTImpl.Cmd_Number(400, 155, 30, FT_OPT_CENTER, veh.launch_cnf.th_speed);
+	FTImpl.Tag(6);
+	FTImpl.Cmd_Button(335, 170, 48, 48, 27, 0, "-");
+	FTImpl.Tag(7);
+	FTImpl.Cmd_Button(414, 170, 48, 48, 27, 0, "+");
+	FTImpl.DLEnd();
+
+
+	common_display();
+}
+
+
+void diag_display(bool diag_shift, bool diag_fuel_st, bool diag_rst){
+	FTImpl.Cmd_Text(240, 32, 28, FT_OPT_CENTER, "Diagnostics");
+
+	FTImpl.Begin(FT_POINTS);
+	FTImpl.PointSize(600);
+
+	FTImpl.Tag(1);
+	if(diag_shift) FTImpl.ColorRGB(0, 255, 0);
+	FTImpl.Vertex2ii(100, 145, 0, 0);
+	FTImpl.ColorRGB(255, 255, 255);
+
+	FTImpl.Tag(2);
+	if(diag_fuel_st) FTImpl.ColorRGB(0, 255, 0);
+	FTImpl.Vertex2ii(230, 145, 0, 0);
+	FTImpl.ColorRGB(255, 255, 255);
+
+	FTImpl.Tag(3);
+	if(diag_rst) FTImpl.ColorRGB(0, 255, 0);
+	FTImpl.Vertex2ii(360, 145, 0, 0);
+	FTImpl.ColorRGB(255, 255, 255);
+
+	FTImpl.End();
+
+
+	if(diag_shift) FTImpl.ColorRGB(0, 255, 0);
+	FTImpl.Cmd_Text(100, 90, 28, FT_OPT_CENTER, "Shift Lights");
+	FTImpl.ColorRGB(255, 255, 255);
+
+	if(diag_fuel_st) FTImpl.ColorRGB(0, 255, 0);
+	FTImpl.Cmd_Text(230, 90, 28, FT_OPT_CENTER, "Fuel Pump");
+	FTImpl.ColorRGB(255, 255, 255);
+
+	if(diag_rst) FTImpl.ColorRGB(0, 255, 0);
+	FTImpl.Cmd_Text(360, 90, 28, FT_OPT_CENTER, "Reset MCU");
+	FTImpl.ColorRGB(255, 255, 255);
+
+
+	common_display();
+}


### PR DESCRIPTION
This one was a doozie even though it really shouldn't have been.

Summary of changes:
1. Moved the the struct that I made a little while ago to store all the vehicle data from canbus.h to VehicleData.h. This didn't actually end up solving anything but it makes more sense since that struct isn't solely related to canbus
2. fixed the include guards in canbus.h
3. moved all the implementations from screen.h to screen.cpp. This was made significantly harder by the fact that the people over at FTDI instantiated the SPI object deep inside a sub-library which broke everything when I tried to include their library from multiple files. Fixed by moving that instantiation into the screen.cpp file
4. moved all of the warning-related data into a new struct so it's easier to pass around
5. some other minor fixes here and there, see the diffs if curious

I think this closes #12 as screen.h was the last not-split header file. Opens up some new issues for cleanup though.