### PR TITLE
touchscreen calibration now done with EEPROM!

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,9 +65,9 @@ tags
 
 ### VisualStudioCode ###
 .vscode/*
-!.vscode/settings.json
+# !.vscode/settings.json
 !.vscode/tasks.json
-!.vscode/launch.json
+# !.vscode/launch.json
 !.vscode/extensions.json
 *.code-workspace
 

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -13,7 +13,7 @@
             "request": "launch",
             "name": "PIO Debug",
             "executable": "/home/intern/repos/steering_wheel/.pio/build/genericSTM32F103C8/firmware.elf",
-            "toolchainBinDir": "/home/intern/.platformio/packages/toolchain-gccarmnoneeabi/bin",
+            "toolchainBinDir": "/home/intern/.platformio/packages/toolchain-gccarmnoneeabi@1.70201.0/bin",
             "svdPath": "/home/intern/.platformio/platforms/ststm32/misc/svd/STM32F103xx.svd",
             "preLaunchTask": {
                 "type": "PlatformIO",
@@ -26,7 +26,7 @@
             "request": "launch",
             "name": "PIO Debug (skip Pre-Debug)",
             "executable": "/home/intern/repos/steering_wheel/.pio/build/genericSTM32F103C8/firmware.elf",
-            "toolchainBinDir": "/home/intern/.platformio/packages/toolchain-gccarmnoneeabi/bin",
+            "toolchainBinDir": "/home/intern/.platformio/packages/toolchain-gccarmnoneeabi@1.70201.0/bin",
             "svdPath": "/home/intern/.platformio/platforms/ststm32/misc/svd/STM32F103xx.svd",
             "internalConsoleOptions": "openOnSessionStart"
         }

--- a/include/Launch.h
+++ b/include/Launch.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include "MasterConfig.h"
+#include <inttypes.h>
+
+
+/*
+ * TYPEDEFS
+ */
+
+// data pertaining to tuning launch control from the steering wheel
+// TODO: store this in eeprom and fetch on boot, returning to default vals
+// if unset
+typedef struct s_launch_cnf {
+	uint8_t rpm = 6000/100;		// default value for launch rpm
+	uint8_t th_speed = 30;		// default value for threshold speed
+} launch_cnf_S;
+
+// launch profile struct, contains data about a given launch profile
+// WIP
+typedef struct s_launch_prof{
+	uint8_t prof_number = 0;
+	const char * prof_desc = "Default Profile";
+	launch_cnf_S conf;
+} launch_prof_S;
+
+
+/*
+ * PUBLIC FUNCTIONS
+ */
+
+extern uint8_t lc_eep_write(launch_prof_S); 
+
+/*
+ * PUBLIC DATA
+ */
+extern launch_prof_S launch_profs [NUM_LAUNCH_PROFS];

--- a/include/MasterConfig.h
+++ b/include/MasterConfig.h
@@ -1,0 +1,60 @@
+/*
+ * Master configuration file for the steering wheel
+ */
+
+#pragma once
+
+/*
+ * DEBUGGING SETTINGD 
+ */
+// set this variable to enable various serial debugging features
+#define DEBUG false 
+// set this variable to wait for a connection over serial before continuing
+#define WAIT_FOR_SERIAL true
+// set this variable to debug the conenction to the mcp2515
+#define DEBUG_CAN false
+// set this variable to reset ts in eeprom calibration to default 
+#define RESET_TS_CALIBRATION false
+
+
+/*
+ * PIN DEFINITIONS
+ */
+#define MCP_CS PB12
+#define MCP_INT PB11
+// pin that is connected to reset pin
+#define RST PB0
+
+
+/*
+ * CAN BUS CONSTANTS 
+ */
+#define can_timeout		5000		// time without CAN message before error occurs (ms)
+#define transmit_ID		0xA0		// CAN Bus transmit ID (messages will be sent with this ID)
+#define recv_id			0x80		// CAN Bus receive ID (messages with this ID will be read)
+
+/*
+ * TIMER CONSTANTS
+ */
+
+// constants for each refresh rate
+// TODO: remove this and be not garbage at programming
+#define fifty_hz    20
+#define ten_hz      100
+#define five_hz     200
+#define one_hz      1000
+
+
+/*
+ * EEPROM LAYOUT CONFIG
+ */
+// TS means Touchscreen
+#define TS_CAL_START   0        // location in "eeprom" to start reading from
+#define TS_CAL_SIZE    4        // number of  bytes per value 
+#define TS_CAL_LEN     6        // number of values to read 
+
+/*
+ * LAUNCH CONTROL CONFIG
+ */
+
+#define NUM_LAUNCH_PROFS 4      // how many launch profiles to have

--- a/include/VehicleData.h
+++ b/include/VehicleData.h
@@ -1,26 +1,13 @@
 #pragma once
 
 #include <inttypes.h>
+#include "Launch.h"
 
 /*
  * TYPEDEFS
  */
 
-
-/*
- * data pertaining to tuning launch control from the steering wheel
- * TODO: store this in eeprom and fetch on boot, returning to default vals
- * if unset
- */
-typedef struct s_launch_cnf {
-	uint8_t rpm = 6000/100;		// default value for launch rpm
-	uint8_t th_speed = 30;		// default value for threshold speed
-} launch_cnf_S;
-
-/*
- * Data that pertains to Steering Wheel IO
- */
-
+// Data that pertains to Steering Wheel IO
 typedef struct s_io_state {
 	/* the four switches on the bottom of the steering wheel
 	 * not counting the one in the middle
@@ -49,6 +36,7 @@ typedef struct s_io_state {
 	bool remote_start;
 } io_state_S;
 
+// Vehicle data struct
 typedef struct s_veh_data {
 	int8_t gear;
 	bool launch;

--- a/include/canbus.h
+++ b/include/canbus.h
@@ -8,20 +8,13 @@
 // Interfaces Used 
 #include "mcp_can_stm.h"
 #include <inttypes.h>
+#include "MasterConfig.h"
 #include "VehicleData.h"
 
 
 /*
  * MACROS
  */
-
-#define MCP_CS PB12
-#define MCP_INT PB11
-
-#define can_timeout		5000		// time without CAN message before error occurs (ms)
-#define transmit_ID		0xA0		// CAN Bus transmit ID (messages will be sent with this ID)
-#define recv_id			0x80		// CAN Bus receive ID (messages with this ID will be read)
-
 // I/O state vals
 // word 0
 #define sw1_st	0b10000000

--- a/include/main.h
+++ b/include/main.h
@@ -6,6 +6,7 @@
 #include <SPI.h>
 #include <Wire.h>
 #include <inttypes.h>
+#include "MasterConfig.h"
 #include "VehicleData.h"
 #include "shiftlights.h"
 #include "canbus.h"
@@ -14,26 +15,13 @@
 #include "Debouncer.h"
 
 
-
-// pin that is connected to rst
-#define RST PB0
-
-
 // TODO: replace all of this with a timer class
 extern uint32_t c_time;
 uint32_t l_time_50 = 0;		    // last time a 50Hz event occured
 uint32_t l_time_10 = 0;		    // last time a 10Hz event occured
 uint32_t l_time_5 = 0;			// last time a 5Hz event occured
 uint32_t l_time_1 = 0;			// last time a 1Hz event occured
-
-
-// constants for each refresh rate
-uint16_t fifty_hz = 20;
-uint16_t ten_hz = 100;
-uint16_t five_hz = 200;
-uint16_t one_hz = 1000;
 // end todo
-
 
 // debounce vars
 Debouncer remote_start = Debouncer(500, 0);

--- a/include/screen.h
+++ b/include/screen.h
@@ -3,9 +3,12 @@
 
 // Interfaces Used 
 #include <inttypes.h>
+#include <EEPROM.h>
 #include <FT_NHD_43RTP_SHIELD.h>
+#include "MasterConfig.h"
 #include "shiftlights.h"
 #include "VehicleData.h"
+
 
 /*
  * MACROS
@@ -14,14 +17,19 @@
 #define SCR_CS_PIN PA0
 #define RAM_FONTS_MICROSS 0
 
+
 /*
  * PRIVATE DATA
  */
 static PROGMEM prog_uchar FONTS_MICROSS[] = {
 	#include "FONTS_MICROSS.h"
 };
-// touchscreen calibration for orange wheel
-extern uint32_t touch_matrix [];
+
+// known good default config values to reset to if necessary
+static const uint32_t touch_cal_default [6] = {32439, 4294966806,
+										4294236873, 4294966575,
+										4294947195, 18508876
+										};
 
 
 // TODO: probably move this to VehicleData.h
@@ -36,7 +44,6 @@ typedef struct s_warning {
 } warning_S;
 
 
-
 /*
  * PUBLIC FUNCTIONS
  */
@@ -47,13 +54,18 @@ extern void diag_display(bool, bool, bool);
 extern bool boot_display();
 extern bool check_display();
 extern uint16_t ts_btn_pressed();
+extern bool ts_eeprom_get();
+extern void ts_cal_get();
 
 
 /*
  * PRIVATE FUNCTIONS
  */
-extern void calibrate_display();
-extern void common_display();
+void calibrate_display();
+void common_display();
+bool ts_write_regs(uint32_t (&)[TS_CAL_LEN]);
+void ts_read_write();
+void ts_eeprom_write(const uint32_t (&)[TS_CAL_LEN]);
 
 
 /*
@@ -61,7 +73,6 @@ extern void common_display();
  */
 extern ShiftLights shift_lights;		// bring in shiftligts object so we can control them
 extern FT800IMPL_SPI FTImpl;			// define screen obj
-extern sTagXY sTagxy;					// define touchscreen obj
 extern warning_S warning;				// define the warning struct above
 
 #endif // SCREEN_H

--- a/platformio.ini
+++ b/platformio.ini
@@ -12,7 +12,7 @@
 platform = ststm32
 board = genericSTM32F103C8
 framework = arduino
-upload_protocol = dfu
+upload_protocol = stlink
 upload_port = "Maple DFU"
 board_build.core = maple
 ;build_flags = -v

--- a/src/Launch.cpp
+++ b/src/Launch.cpp
@@ -1,0 +1,12 @@
+#include "Launch.h"
+
+
+uint8_t lc_init_profs(){
+    for(uint8_t i=0; i<NUM_LAUNCH_PROFS; i++){
+    }
+    return launch_profs[0].prof_number;
+}
+
+void ln_eep_write(launch_prof_S prof){
+
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7,14 +7,15 @@ SPIClass SPI_2(2);
 uint32_t c_time = millis();
 
 void setup(){
+#if DEBUG
 	Serial.begin(115200);
-	
-/* DEBUG CODE
+#if WAIT_FOR_SERIAL
 	// wait for computer to connect to serial before continuing
 	while(Serial.read() <= 0);
+#endif
 	Serial.println("Serial connected.");
-
-// DEBUG CAN CONNECTION
+#if DEBUG_CAN
+	// Debug connection to MCP2515 
 	// verify connection to can bus module
 	while(!(CAN_OK == CAN.begin(CAN_1000KBPS, PB12))){
 		Serial.print("MCP2515 Connection Failed, retrying ");
@@ -22,6 +23,8 @@ void setup(){
 		delay(100);
 	}
 	Serial.println("MCP2515 Connection Successfull!");
+#endif
+#endif
 // */
 	// define all input pins
 	uint8_t inputs [13] = {PB3, PB4, PB6, PB8, PA8, PA9, PA10, PA15, PB1, PA7, PA6, PA5, PA4};
@@ -40,14 +43,6 @@ void setup(){
 
 	// run the shift light startup sequence
 	shift_lights.LedStartup();
-
-/* Uncomment when calibrating touch screen
-	for(int i=0; i<6; i++)
-	{
-		Serial.print(touch_matrix[i]); Serial.print(" ");
-	}
-	Serial.println();
-*/
 
 	if(!(CAN_OK == CAN.begin(CAN_1000KBPS, MCP_CS))){
 		warning.current = 0;
@@ -90,17 +85,18 @@ void loop(){
 
 	if(c_time - l_time_10 > ten_hz){
 		diag_shift = 0;
-		uint16_t ts_btn = ts_btn_pressed();
-
 		int colors [2] = {0x0, 0x00FF00};
+
+		uint16_t ts_btn = ts_btn_pressed();
 		switch(ts_btn){
 		case 0:
+		// no 0th button
+		// represents the no button press case, reset debounce timers
 			diag_fuel_deb.Reset();
 			launch_rpm_minus.Reset();
 			launch_rpm_plus.Reset();
 			launch_thresh_minus.Reset();
 			launch_thresh_plus.Reset();
-		// no 0th button
 			break;
 		case 1:
 		// case 1, shift light diagnostics


### PR DESCRIPTION
Automatically loads cal values from eeprom instead of using defaults
if the eeprom is empty or faulted, loads the defaults
this means that we can now add a button on the steering wheel somewhere
to recalibrate the touchscreen, and those values will actually be
stored!

Also made MasterConfig.h and started moving some #defines there. This
file will basically contain all the settings that you might want to
change

Added preprocessor-controlled debug blocks. If you want to debug, set
the appropriate values in MasterConfig.h and the debug code will be
compiled. If you don't want to debug, the code won't even be compiled!

addresses #14, started working on doing the same as above but for launch
profiles. Stopped because Anastasia wanted to work on it.